### PR TITLE
rolling and crouching fixes

### DIFF
--- a/Project GP/Assets/Scripts/Player Scripts/PlayerMovementControl.cs
+++ b/Project GP/Assets/Scripts/Player Scripts/PlayerMovementControl.cs
@@ -344,7 +344,7 @@ public class PlayerMovementControl : MonoBehaviour
     private void roll()
     {
         // If player is not currently rolling and there has been sufficient time since last roll
-        if (!isRoll && rollDelay <= 0)
+        if ((Input.GetKey("d") || Input.GetKey("a")) && !isRoll && rollDelay <= 0)
         {
             isRoll = true;
             isInvincible = true;
@@ -445,6 +445,21 @@ public class PlayerMovementControl : MonoBehaviour
         }
     }
 
+    private bool checkCrouchUp()
+    {
+        RaycastHit2D upRightRay = Physics2D.Raycast(transform.position + new Vector3((coll.bounds.size.x / 2f), 0), Vector2.up, collSizeY * 2, groundLayer);
+        RaycastHit2D upLeftRay = Physics2D.Raycast(transform.position - new Vector3((coll.bounds.size.x / 2f), 0), Vector2.up, collSizeY * 2, groundLayer);
+
+        //Debug.DrawRay(transform.position + new Vector3((coll.bounds.size.x / 2f), 0), Vector3.up * collSizeY * 2, Color.red);
+        //Debug.DrawRay(transform.position - new Vector3((coll.bounds.size.x / 2f), 0), Vector3.up * collSizeY * 2, Color.red);
+
+        if (upRightRay.collider != null || upLeftRay.collider != null)
+        {
+            return false;
+        }
+        return true;
+    }
+
     // Function called in Update() checking the crouching
     private void checkCrouch()
     {
@@ -475,19 +490,22 @@ public class PlayerMovementControl : MonoBehaviour
         }
 
         // Check if crouch key is no longer being pressed
-        if (Input.GetKeyUp(KeyCode.LeftControl))
+        if (Input.GetKeyUp(KeyCode.LeftControl) && checkCrouchUp())
         {
             if (toggleCrouch == -1) // if toggle crouch is not on
             {
                 crouch(false);
             }
         }
-        else if (toggleCrouch == 0) // toggle crouch is on and currently crouched
+        else if (toggleCrouch == 0 && checkCrouchUp()) // toggle crouch is on and currently crouched
         {
             if (toggleCrouch == 0)
             {
                 toggleCrouch = -1;  // set toggle to none
             }
+            crouch(false);
+        } else if (toggleCrouch == -1 && !Input.GetKey(KeyCode.LeftControl) && checkCrouchUp() && isCrouching)
+        {
             crouch(false);
         }
     }

--- a/Project GP/Assets/Scripts/Player Scripts/PlayerMovementControl.cs
+++ b/Project GP/Assets/Scripts/Player Scripts/PlayerMovementControl.cs
@@ -480,7 +480,7 @@ public class PlayerMovementControl : MonoBehaviour
         }
 
         // Check if crouch key is being pressed
-        if (Input.GetKeyDown(KeyCode.LeftControl) && toggleCrouch != 1) // if crouch is pressed and toggle crouch not currently active
+        if (Input.GetKeyDown(KeyCode.LeftControl) && toggleCrouch != 1 && !isCrouching) // if crouch is pressed and toggle crouch not currently active
         {
             crouch(true);
         }


### PR DESCRIPTION
Can not roll if no movement key is pressed

Can not crouch up if player is below a platform that is lower than the players's hitbox. If hold crouch is released when the player is below a platform the will stay crouched until they are no longer under the platform